### PR TITLE
Print unresolved recursive values as their defining expressions, instead of `??`

### DIFF
--- a/src/rmap/core.clj
+++ b/src/rmap/core.clj
@@ -46,7 +46,7 @@
   (print-method reftag *out*))
 
 (defmethod print-method RVal [^rmap.core.RVal rval ^java.io.Writer writer]
-  (.write writer "??"))
+  (.write writer (str "(rval " (:ref/sexp (meta (.f rval))) ")")))
 
 (defmethod simple-dispatch RVal [^rmap.core.RVal rval]
   (print-method rval *out*))
@@ -64,7 +64,8 @@
   not evaluated yet. The body can use the [[ref]] function while it is
   evaluated, or you can bind it locally for use at a later stage."
   [& body]
-  `(RVal. (fn [ref#]
+  `(RVal. ^{:ref/sexp '~@body}
+          (fn [ref#]
             (binding [ref ref#]
               ~@body))))
 


### PR DESCRIPTION
# Problem

While developing rmaps in a REPL session, they are printed with all the values appearing as `??`, which makes debugging hard.

The following 3 expressions:
```clojure
  @(def my-map
     {:foo 1
      :bar (rval (inc (ref :foo)))})

  @(def my-map
     (rmap {:foo 1
            :bar (inc (ref :foo))}))

  (valuate! my-map)
```

yield this output:
```clojure
=> {:foo 1, :bar ??}
=> {:foo ??, :bar ??}
=> {:foo 1, :bar 2}
```
# Solution

Store the rval-computing expressions (as metadata on their underlying function) and print those expressions, instead of `??`.

The same 3 expressions as above, will be printed as:
```
=> {:foo 1, :bar (rval (inc (ref :foo)))}
=> {:foo (rval 1), :bar (rval (inc (ref :foo)))}
=> {:foo 1, :bar 2}
```

While the printed values happen to be homoiconic, it was not a design goal.